### PR TITLE
Updated ST7735R Driver to use PB6 for D/C

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -177,13 +177,17 @@ int main(void)
     //
     FPUInit();
 
+
+    CharterInit(true);
+    CharterSplashScreen();
+    CharterClrScreen();
+    CharterFlush();
+
     ConsoleInit();
     UARTprintf("IMU Visualization Test\r\n");
     UARTprintf("Initializing...\r\n");
     IMUInit(&g_sMPU9X50Inst, &g_sAK8963Inst, &g_sI2CMInst);
     BatteryInit ();
-    CharterInit(true);
-    CharterClrScreen();
     UARTprintf("Done\r\n");
 
     bool result;

--- a/main/main.c
+++ b/main/main.c
@@ -107,11 +107,11 @@ volatile uint_fast8_t g_vui8AK8963DoneFlag = false, g_vui8AK8963ErrorFlag = 0;
 
 void Timer0IntHandler(void)
 {
-  TimerIntClear(TIMER0_BASE, TIMER_TIMA_TIMEOUT);
+    TimerIntClear(TIMER0_BASE, TIMER_TIMA_TIMEOUT);
 
     IMUDataRead();
 
-  IMUDataGetFloat(g_pfAccel, g_pfGyro, g_pfMag);
+    IMUDataGetFloat(g_pfAccel, g_pfGyro, g_pfMag);
     UpdateHeading(g_pfGyro, g_pfMag);
     UpdatePosition(g_pfAccel);
     g_pfHead[0] = GetRelativeHeading(0, 0);

--- a/peripherals/st7735r128x128x18.c
+++ b/peripherals/st7735r128x128x18.c
@@ -97,6 +97,7 @@
 //*****************************************************************************
 #define DISPLAY_SSI_PERIPH          SYSCTL_PERIPH_SSI0
 #define DISPLAY_SSI_GPIO_PERIPH     SYSCTL_PERIPH_GPIOA
+#define DISPLAY_DC_GPIO_PERIPH      SYSCTL_PERIPH_GPIOB
 #define DISPLAY_RST_GPIO_PERIPH     SYSCTL_PERIPH_GPIOD
 #define DISPLAY_PWR_GPIO_PERIPH     SYSCTL_PERIPH_GPIOC
 
@@ -139,8 +140,8 @@
 // Defines the port and pins for the display Data/Command (D/C) signal.
 //
 //*****************************************************************************
-#define DISPLAY_D_C_PORT            GPIO_PORTA_BASE
-#define DISPLAY_D_C_PIN             GPIO_PIN_4
+#define DISPLAY_D_C_PORT            GPIO_PORTB_BASE
+#define DISPLAY_D_C_PIN             GPIO_PIN_6
 
 //*****************************************************************************
 //
@@ -901,6 +902,7 @@ ST7735R128x128x18PeriphInit(void)
     //
     MAP_SysCtlPeripheralEnable(DISPLAY_SSI_PERIPH);
     MAP_SysCtlPeripheralEnable(DISPLAY_SSI_GPIO_PERIPH);
+    MAP_SysCtlPeripheralEnable(DISPLAY_DC_GPIO_PERIPH);
     MAP_SysCtlPeripheralEnable(DISPLAY_RST_GPIO_PERIPH);
     MAP_SysCtlPeripheralEnable(DISPLAY_PWR_GPIO_PERIPH);
 


### PR DESCRIPTION
In order to allow PA4 to be used as MISO0 and not have a floating signal, D/C GPIO was switched to use PB6.